### PR TITLE
docs: Fix simple typo, mulitple -> multiple

### DIFF
--- a/lib/handlebars/compiler/whitespace-control.js
+++ b/lib/handlebars/compiler/whitespace-control.js
@@ -187,7 +187,7 @@ function isNextWhitespace(body, i, isRoot) {
 //
 // If i is undefined, then the first child will be marked as such.
 //
-// If mulitple is truthy then all whitespace will be stripped out until non-whitespace
+// If multiple is truthy then all whitespace will be stripped out until non-whitespace
 // content is met.
 function omitRight(body, i, multiple) {
   let current = body[i == null ? 0 : i + 1];
@@ -212,7 +212,7 @@ function omitRight(body, i, multiple) {
 //
 // If i is undefined then the last child will be marked as such.
 //
-// If mulitple is truthy then all whitespace will be stripped out until non-whitespace
+// If multiple is truthy then all whitespace will be stripped out until non-whitespace
 // content is met.
 function omitLeft(body, i, multiple) {
   let current = body[i == null ? body.length - 1 : i - 1];


### PR DESCRIPTION
There is a small typo in lib/handlebars/compiler/whitespace-control.js.

Should read `multiple` rather than `mulitple`.

