### PR TITLE
Make ` delimit string literals

### DIFF
--- a/spec/tokenizer.js
+++ b/spec/tokenizer.js
@@ -453,6 +453,12 @@ describe('Tokenizer', function() {
     shouldBeToken(result[3], 'STRING', 'baz');
   });
 
+  it('tokenizes mustaches with String params using back-ticks as "OPEN ID ID STRING CLOSE"', function() {
+    var result = tokenize('{{ foo bar `baz` }}');
+    shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'STRING', 'CLOSE']);
+    shouldBeToken(result[3], 'STRING', 'baz');
+  });
+
   it('tokenizes String params with spaces inside as "STRING"', function() {
     var result = tokenize('{{ foo bar "baz bat" }}');
     shouldMatchTokens(result, ['OPEN', 'ID', 'ID', 'STRING', 'CLOSE']);
@@ -469,6 +475,12 @@ describe('Tokenizer', function() {
     var result = tokenize("{{ foo 'bar\\'baz' }}");
     shouldMatchTokens(result, ['OPEN', 'ID', 'STRING', 'CLOSE']);
     shouldBeToken(result[2], 'STRING', "bar'baz");
+  });
+
+  it('tokenizes String params using back-tics with escapes quotes as STRING', function() {
+    var result = tokenize('{{ foo `bar\\`baz` }}');
+    shouldMatchTokens(result, ['OPEN', 'ID', 'STRING', 'CLOSE']);
+    shouldBeToken(result[2], 'STRING', 'bar`baz');
   });
 
   it('tokenizes numbers', function() {

--- a/src/handlebars.l
+++ b/src/handlebars.l
@@ -109,6 +109,7 @@ ID    [^\s!"#%-,\.\/;->@\[-\^`\{-~]+/{LOOKAHEAD}
 <mu>{RIGHT_STRIP}?"}}"           this.popState(); return 'CLOSE';
 <mu>'"'("\\"["]|[^"])*'"'        yytext = strip(1,2).replace(/\\"/g,'"'); return 'STRING';
 <mu>"'"("\\"[']|[^'])*"'"        yytext = strip(1,2).replace(/\\'/g,"'"); return 'STRING';
+<mu>"`"("\\"[`]|[^`])*"`"        yytext = strip(1,2).replace(/\\`/g,"`"); return 'STRING';
 <mu>"@"                          return 'DATA';
 <mu>"true"/{LITERAL_LOOKAHEAD}   return 'BOOLEAN';
 <mu>"false"/{LITERAL_LOOKAHEAD}  return 'BOOLEAN';


### PR DESCRIPTION
I would like to allow my users to write handlebars templates with complex string literals in helper params, containing lots of `"`s and `'`s without the need to escape them. I see that `` ` `` is a reserved control character, which is awesome, but I didn't see its use in current docs. Is this something that can be added to `v5`?

Thanks!