### PR TITLE
Support Map for iteration and nested paths

### DIFF
--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -3,7 +3,8 @@ import {
   blockParams,
   createFrame,
   isArray,
-  isFunction
+  isFunction,
+  isMap
 } from '../utils';
 import Exception from '../exception';
 
@@ -60,7 +61,7 @@ export default function(instance) {
             execIteration(i, context[i], i, i === context.length - 1);
           }
         }
-      } else if (context instanceof Map) {
+      } else if (isMap(context)) {
         const j = context.size - 1;
         for (const [key, value] of context) {
           execIteration(key, value, i, i === j);

--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -33,7 +33,7 @@ export default function(instance) {
       data = createFrame(options.data);
     }
 
-    function execIteration(field, index, last) {
+    function execIteration(field, value, index, last) {
       if (data) {
         data.key = field;
         data.index = index;
@@ -47,12 +47,9 @@ export default function(instance) {
 
       ret =
         ret +
-        fn(context[field], {
+        fn(value, {
           data: data,
-          blockParams: blockParams(
-            [context[field], field],
-            [contextPath + field, null]
-          )
+          blockParams: blockParams([value, field], [contextPath + field, null])
         });
     }
 
@@ -60,8 +57,14 @@ export default function(instance) {
       if (isArray(context)) {
         for (let j = context.length; i < j; i++) {
           if (i in context) {
-            execIteration(i, i, i === context.length - 1);
+            execIteration(i, context[i], i, i === context.length - 1);
           }
+        }
+      } else if (context instanceof Map) {
+        const j = context.size - 1;
+        for (const [key, value] of context) {
+          execIteration(key, value, i, i === j);
+          i++;
         }
       } else if (global.Symbol && context[global.Symbol.iterator]) {
         const newContext = [];
@@ -71,7 +74,7 @@ export default function(instance) {
         }
         context = newContext;
         for (let j = context.length; i < j; i++) {
-          execIteration(i, i, i === context.length - 1);
+          execIteration(i, context[i], i, i === context.length - 1);
         }
       } else {
         let priorKey;
@@ -81,13 +84,13 @@ export default function(instance) {
           // the last iteration without have to scan the object twice and create
           // an itermediate keys array.
           if (priorKey !== undefined) {
-            execIteration(priorKey, i - 1);
+            execIteration(priorKey, context[priorKey], i - 1);
           }
           priorKey = key;
           i++;
         });
         if (priorKey !== undefined) {
-          execIteration(priorKey, i - 1, true);
+          execIteration(priorKey, context[priorKey], i - 1, true);
         }
       }
     }

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -127,6 +127,9 @@ export function template(templateSpec, env) {
       return obj[name];
     },
     lookupProperty: function(parent, propertyName) {
+      if (parent instanceof Map) {
+        return parent.get(propertyName);
+      }
       let result = parent[propertyName];
       if (result == null) {
         return result;

--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -127,7 +127,7 @@ export function template(templateSpec, env) {
       return obj[name];
     },
     lookupProperty: function(parent, propertyName) {
-      if (parent instanceof Map) {
+      if (Utils.isMap(parent)) {
         return parent.get(propertyName);
       }
       let result = parent[propertyName];

--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -57,6 +57,12 @@ export const isArray =
       : false;
   };
 
+export const isMap = function(value) {
+  return value && typeof value === 'object'
+    ? toString.call(value) === '[object Map]'
+    : false;
+};
+
 // Older IE versions do not directly support indexOf so we must implement our own, sadly.
 export function indexOf(array, value) {
   for (let i = 0, len = array.length; i < len; i++) {

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -394,6 +394,17 @@ describe('basic context', function() {
     );
   });
 
+  it('nested paths with Map', function() {
+    var map = new Map();
+    map.set('expression', 'beautiful');
+    shouldCompileTo(
+      'Goodbye {{foo/expression}} world!',
+      { foo: map },
+      'Goodbye beautiful world!',
+      'Nested paths access nested objects'
+    );
+  });
+
   it('nested paths with empty string value', function() {
     shouldCompileTo(
       'Goodbye {{alan/expression}} world!',

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -397,12 +397,9 @@ describe('basic context', function() {
   it('nested paths with Map', function() {
     var map = new Map();
     map.set('expression', 'beautiful');
-    shouldCompileTo(
-      'Goodbye {{foo/expression}} world!',
-      { foo: map },
-      'Goodbye beautiful world!',
-      'Nested paths access nested objects'
-    );
+    expectTemplate('Goodbye {{foo/expression}} world!')
+      .withInput({ foo: map })
+      .toCompileTo('Goodbye beautiful world!');
   });
 
   it('nested paths with empty string value', function() {

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -551,6 +551,29 @@ describe('builtin helpers', function() {
         );
       });
     }
+
+    it('each on Map and @key', function() {
+      var goodbyes = new Map();
+      goodbyes.set('first', 'goodbye');
+      goodbyes.set('second', 'Goodbye');
+      goodbyes.set('last', 'GOODBYE');
+      var goodbyesEmpty = new Map();
+      var string =
+        '{{#each goodbyes}}{{@key}}. {{.}}! {{/each}}cruel {{world}}!';
+      var hash = { goodbyes: goodbyes, world: 'world' };
+      shouldCompileTo(
+        string,
+        hash,
+        'first. goodbye! second. Goodbye! last. GOODBYE! cruel world!',
+        'each with map argument iterates over entries when not empty'
+      );
+      shouldCompileTo(
+        string,
+        { goodbyes: goodbyesEmpty, world: 'world' },
+        'cruel world!',
+        'each with map argument ignores the contents when empty'
+      );
+    });
   });
 
   describe('#log', function() {

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -561,18 +561,16 @@ describe('builtin helpers', function() {
       var string =
         '{{#each goodbyes}}{{@key}}. {{.}}! {{/each}}cruel {{world}}!';
       var hash = { goodbyes: goodbyes, world: 'world' };
-      shouldCompileTo(
-        string,
-        hash,
-        'first. goodbye! second. Goodbye! last. GOODBYE! cruel world!',
-        'each with map argument iterates over entries when not empty'
-      );
-      shouldCompileTo(
-        string,
-        { goodbyes: goodbyesEmpty, world: 'world' },
-        'cruel world!',
-        'each with map argument ignores the contents when empty'
-      );
+
+      expectTemplate(string)
+        .withInput(hash)
+        .toCompileTo(
+          'first. goodbye! second. Goodbye! last. GOODBYE! cruel world!'
+        );
+
+      expectTemplate(string)
+        .withInput({ goodbyes: goodbyesEmpty, world: 'world' })
+        .toCompileTo('cruel world!');
     });
   });
 


### PR DESCRIPTION
Re #1418 and #1557 this PR adds support for accessing properties in Maps, and iterating over the values in Maps using `#each`.

e.g.

```javascript
var foo = new Map();
foo.set('expression', 'beautiful');
...
```
`+`
```handlebars
Goodbye {{foo/expression}} world!
{{#each foo}}
The {{@key}} is {{.}}.
{{/each}}
```
`=`
```
Goodbye beautiful world!
The expression is beautiful.
```


- [X] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [X] Maintain the existing code style
- [X] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [X] Have good commit messages
- [X] Have tests
- [X] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [X] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [X] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 

