### PR TITLE
Moved `uglify-js` from `optionalDependencies` to `peerDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1729,7 +1729,8 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -10905,7 +10906,7 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
       "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
-      "optional": true,
+      "dev": true,
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "source-map": "^0.6.1",
     "yargs": "^15.3.1"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "uglify-js": "^3.1.4"
   },
   "devDependencies": {
@@ -69,6 +69,7 @@
     "semver": "^5.0.1",
     "sinon": "^7.5.0",
     "typescript": "^3.4.3",
+    "uglify-js": "^3.1.4",
     "underscore": "^1.5.1",
     "webpack": "^1.12.6",
     "webpack-dev-server": "^1.12.1"


### PR DESCRIPTION
Addresses #1488, with this change "uglify-js" will no longer be automatically installed. When this occurs `npm install` (and some of its analogues) will log a message indicating that then peer dependency was not installed. This behaviour extends to the package with the listed peer dependency (handlebars in this case), as such "uglify-js" was also added to `devDependencies` so that it is installed for use in tests (with the same version constraint).

No new tests were created as the existing optional dependency tests already correctly covered this scenario (with the "uglify-js" missing scenario addressed via mocks).

------------------------------------------------
### PR Checklist
Before creating a pull-request, please check https://github.com/wycats/handlebars.js/blob/master/CONTRIBUTING.md first.

Generally we like to see pull requests that

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] _(I hope)_ Have good commit messages
- [x] _(Already covered)_ Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] _(5.0 target, hence pointed to master)_ Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 