### PR TITLE
Don't rely on Nodejs `global` object

### DIFF
--- a/lib/.eslintrc.js
+++ b/lib/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  globals: {
+    global: 'off'
+  }
+};

--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -63,9 +63,9 @@ export default function(instance) {
             execIteration(i, i, i === context.length - 1);
           }
         }
-      } else if (global.Symbol && context[global.Symbol.iterator]) {
+      } else if (typeof Symbol === 'function' && context[Symbol.iterator]) {
         const newContext = [];
-        const iterator = context[global.Symbol.iterator]();
+        const iterator = context[Symbol.iterator]();
         for (let it = iterator.next(); !it.done; it = iterator.next()) {
           newContext.push(it.value);
         }

--- a/lib/handlebars/no-conflict.js
+++ b/lib/handlebars/no-conflict.js
@@ -1,6 +1,6 @@
 export default function(Handlebars) {
   /* istanbul ignore next */
-  let root = typeof global !== 'undefined' ? global : window,
+  let root = typeof global !== 'undefined' ? global : window, // eslint-disable-line no-undef
     $Handlebars = root.Handlebars;
   /* istanbul ignore next */
   Handlebars.noConflict = function() {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eco": "~1.1.0-rc-3",
     "eslint": "^6.7.2",
     "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-compat": "^3.3.0",
+    "eslint-plugin-compat": "^3.8.0",
     "eslint-plugin-es5": "^1.4.1",
     "fs-extra": "^8.1.0",
     "grunt": "^1.0.4",


### PR DESCRIPTION
### Description

If `global` is used and handlebars is compiled for browser
usage without a Node.js `global` polyfill, handlebars
fails with a `global is undefined` error.

Fixes #1593

---

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [ ] Have tests
- [ ] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 