### PR TITLE
Fix the error when importing Handlebars as ESM module

### DIFF
--- a/lib/handlebars/internal/proto-access.js
+++ b/lib/handlebars/internal/proto-access.js
@@ -1,5 +1,5 @@
 import { createNewLookupObject } from './create-new-lookup-object';
-import * as logger from '../logger';
+import logger from '../logger';
 
 const loggedProperties = Object.create(null);
 


### PR DESCRIPTION
Strict ESM loaders such as Rollup make a strict distinction between the properties of the default exported object and the named export, so importing Handlebars as ESM using Rollup will result in the following error:

```
$ cat main.js 
import 'handlebars/lib/handlebars.runtime';

$ node_modules/.bin/rollup main.js -p node-resolve > /dev/null

main.js → stdout...
(!) Missing exports
https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module
../src/github.com/handlebars-lang/handlebars.js/lib/handlebars/internal/proto-access.js
log is not exported by ../src/github.com/handlebars-lang/handlebars.js/lib/handlebars/logger.js
55:   if (loggedProperties[propertyName] !== true) {
56:     loggedProperties[propertyName] = true;
57:     logger.log(
               ^
58:       'error',
59:       `Handlebars: Access has been denied to resolve the property "${propertyName}" because it is not an "own property" of its parent.\n` +
```

---

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [ ] Have tests
- [ ] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [ ] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR. 