### PR TITLE
Fix type "RuntimeOptions" also accepting string partials

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,7 @@ declare namespace Handlebars {
       partial?: boolean;
       depths?: any[];
       helpers?: { [name: string]: Function };
-      partials?: { [name: string]: HandlebarsTemplateDelegate };
+      partials?: { [name: string]: Template };
       decorators?: { [name: string]: Function };
       data?: any;
       blockParams?: any[];
@@ -60,7 +60,7 @@ declare namespace Handlebars {
   export function unregisterHelper(name: string): void;
 
   export function registerPartial(name: string, fn: Template): void;
-  export function registerPartial(spec: { [name: string]: HandlebarsTemplateDelegate }): void;
+  export function registerPartial(spec: { [name: string]: Template }): void;
   export function unregisterPartial(name: string): void;
 
   // TODO: replace Function with actual signature

--- a/types/test.ts
+++ b/types/test.ts
@@ -249,6 +249,9 @@ function testProtoAccessControlControlOptions() {
       allowedProtoProperties: { allowedProperty: true, forbiddenProperty: false },
       allowProtoMethodsByDefault: true,
       allowProtoPropertiesByDefault: false,
+      partials: {
+        link: '<a href="/people/{{id}}">{{name}}</a>'
+      }
     }
   );
 }


### PR DESCRIPTION
Quick fix to `types/index.d.ts` to accept passing strings for partials:

```typescript
template({}, { partials: { link: '<a href="/people/{{id}}">{{name}}</a>' } });
```

(PS: Not sure if this PR should target branch `4.x` or `master`, feel free to change the target branch if needed)