### PR TITLE
runtime: use custom escape function

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -153,7 +153,7 @@ export function template(templateSpec, env) {
       return typeof current === 'function' ? current.call(context) : current;
     },
 
-    escapeExpression: Utils.escapeExpression,
+    escapeExpression: env.escapeExpression,
     invokePartial: invokePartialWrapper,
 
     fn: function(i) {


### PR DESCRIPTION
Without this change, the line

    hb.escapeExpression = Utils.escapeExpression;

in top-level `create()` is unused.

Users who use a custom escape can only do so by modifying/corrupting
the global Utils.escapeExpression, or using deep copies.