### PR TITLE
The changes were applied to the precompiler before the file was compiled

### DIFF
--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -22,6 +22,21 @@ module.exports.loadTemplates = function(opts, callback) {
   });
 };
 
+// Erfan Kamalian
+
+function myNewLine(string) {
+
+
+  // use regex format to replace all \n with <br> in clean way!  
+
+  const out = string.replace(/(?:\r\n|\r|\n)/g, '<br>');
+
+
+  // return output
+
+  return out;
+}
+
 function loadStrings(opts, callback) {
   let strings = arrayCast(opts.string),
     names = arrayCast(opts.name);
@@ -56,7 +71,11 @@ function loadStrings(opts, callback) {
       strings = strings.map((string, index) => ({
         name: names[index],
         path: names[index],
-        source: string
+
+
+        // fix issue here :)
+
+        source: myNewLine(string),
       }));
       callback(err, strings);
     }


### PR DESCRIPTION
### How to fix it

To solve this problem, the explanations related to it were read first.
After studying the code, searching, researching and developing (R&D) about this problem, it was finally solved as follows:
Regex documents were studied and designed string with existing examples that can find \n and applied using the replace function.
Then, to optimize and not implement the dirty code, this function is called on the final file before compilation in precompiler.js.

Erfan Kamalian
web programming course -- Sharif University of Technology