### PR TITLE
Remove non-standard `package.json` property

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "handlebars",
-  "barename": "handlebars",
   "version": "5.0.0-alpha.1",
   "description": "Handlebars provides the power necessary to let you build semantic templates effectively with no frustration",
   "homepage": "http://www.handlebarsjs.com/",


### PR DESCRIPTION
This was added in 88ee4757e77f97afb206132eddb64e688700eb37
and is not used anymore since a2687fdf501a878df264d9cbefd31c0601a077e7.