### PR TITLE
Enable IDE code-highlighting for bin-file

### DIFF
--- a/bin/handlebars.js
+++ b/bin/handlebars.js
@@ -111,7 +111,6 @@ delete argv._;
 
 const Precompiler = require('../dist/cjs/precompiler');
 Precompiler.loadTemplates(argv, function(err, opts) {
-
   if (err) {
     throw err;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "yargs": "^16.2.0"
       },
       "bin": {
-        "handlebars": "bin/handlebars"
+        "handlebars": "bin/handlebars.js"
       },
       "devDependencies": {
         "@definitelytyped/dtslint": "^0.0.100",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "./runtime": "./dist/cjs/handlebars.runtime.js"
   },
   "bin": {
-    "handlebars": "bin/handlebars"
+    "handlebars": "bin/handlebars.js"
   },
   "scripts": {
     "build": "grunt build",

--- a/spec/expected/help.menu.txt
+++ b/spec/expected/help.menu.txt
@@ -1,5 +1,5 @@
 Precompile handlebar templates.
-Usage: handlebars [template|directory]...
+Usage: handlebars.js [template|directory]...
 
 Options:
   --help               Outputs this message                                                                    [boolean]

--- a/tasks/test-bin.js
+++ b/tasks/test-bin.js
@@ -219,9 +219,9 @@ function executeBinHandlebars(...args) {
   if (os.platform() === 'win32') {
     // On Windows, the executable handlebars.js file cannot be run directly
     const nodeJs = process.argv[0];
-    return execFilesSyncUtf8(nodeJs, ['./bin/handlebars'].concat(args));
+    return execFilesSyncUtf8(nodeJs, ['./bin/handlebars.js'].concat(args));
   }
-  return execFilesSyncUtf8('./bin/handlebars', args);
+  return execFilesSyncUtf8('./bin/handlebars.js', args);
 }
 
 function execFilesSyncUtf8(command, args) {


### PR DESCRIPTION
By adding the `.js`-extension to the bin-file, IDEs will
know that js code-highlighting should be applied to the
file, which makes it easier for devs to read the code.

For comparison, other JS libraries also use the `.js`-extension:

* https://github.com/webpack/webpack/blob/v5.65.0/bin/webpack.js
* https://github.com/webpack/webpack/blob/v5.65.0/package.json#L126