### PR TITLE
Use https instead of git for mustache submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spec/mustache"]
 	path = spec/mustache
-	url = git://github.com/mustache/spec.git
+	url = https://github.com/mustache/spec.git


### PR DESCRIPTION
GitHub has [sunset the unencrypted git protocol](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git). This updates the submodule to use `https` instead.

Previously:
```
Submodule 'spec/mustache' (git://github.com/mustache/spec.git) registered for path 'spec/mustache'
Cloning into '/handlebars.js/spec/mustache'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: clone of 'git://github.com/mustache/spec.git' into submodule path '/handlebars.js/spec/mustache' failed
Failed to clone 'spec/mustache'. Retry scheduled
```

With this:
```
Submodule 'spec/mustache' (https://github.com/mustache/spec.git) registered for path 'spec/mustache'
Cloning into '/handlebars.js/spec/mustache'...
remote: Enumerating objects: 800, done.
remote: Counting objects: 100% (139/139), done.
remote: Compressing objects: 100% (85/85), done.
remote: Total 800 (delta 86), reused 92 (delta 54), pack-reused 661
Receiving objects: 100% (800/800), 168.45 KiB | 434.00 KiB/s, done.
Resolving deltas: 100% (509/509), done.
Submodule path 'spec/mustache': checked out '83b0721610a4e11832e83df19c73ace3289972b9'
```