### PR TITLE
Fix webpack browser install

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,9 @@
     "uglify-js": "^3.1.4",
     "underscore": "^1.5.1",
     "webpack": "^1.12.6",
-    "webpack-dev-server": "^1.12.1"
+    "webpack-dev-server": "^1.12.1",
+    "grunt": "^1.4.1",
+    "coffeescript": "^2.6.1",
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "main": "lib/index.js",
   "types": "types/index.d.ts",
   "browser": {
-    ".": "./dist/cjs/handlebars.js",
+    "./lib/index.js": "./dist/cjs/handlebars.js",
     "./runtime": "./dist/cjs/handlebars.runtime.js"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "underscore": "^1.5.1",
     "webpack": "^1.12.6",
     "webpack-dev-server": "^1.12.1",
-    "grunt": "^1.4.1",
     "coffeescript": "^2.6.1",
   },
   "main": "lib/index.js",
@@ -84,7 +83,7 @@
     "handlebars": "bin/handlebars.js"
   },
   "scripts": {
-    "prepare": "npm run build",
+    "prepare": "npm i -D && npm run build",
     "build": "grunt build",
     "format": "prettier --write '**/*.js' && eslint --fix .",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",

--- a/package.json
+++ b/package.json
@@ -1,136 +1,135 @@
 {
-  "name": "handlebars",
-  "version": "5.0.0-alpha.1",
-  "description": "Handlebars provides the power necessary to let you build semantic templates effectively with no frustration",
-  "homepage": "https://www.handlebarsjs.com/",
-  "keywords": [
-    "handlebars",
-    "mustache",
-    "template",
-    "html"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/handlebars-lang/handlebars.js.git"
-  },
-  "author": "Yehuda Katz",
-  "license": "MIT",
-  "readmeFilename": "README.markdown",
-  "engines": {
-    "node": ">=10"
-  },
-  "dependencies": {
-    "@handlebars/parser": "^1.1.0",
-    "neo-async": "^2.6.2",
-    "source-map": "^0.6.1",
-    "yargs": "^16.2.0"
-  },
-  "peerDependencies": {
-    "uglify-js": "^3.1.4"
-  },
-  "devDependencies": {
-    "@definitelytyped/dtslint": "^0.0.100",
-    "@playwright/test": "^1.17.1",
-    "aws-sdk": "^2.1.49",
-    "babel-loader": "^5.0.0",
-    "babel-runtime": "^5.1.10",
-    "benchmark": "~1.0",
-    "chai": "^4.2.0",
-    "chai-diff": "^1.0.1",
-    "concurrently": "^5.0.0",
-    "dirty-chai": "^2.0.1",
-    "dustjs-linkedin": "^2.0.2",
-    "eslint": "^6.7.2",
-    "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-compat": "^3.13.0",
-    "eslint-plugin-es5": "^1.4.1",
-    "fs-extra": "^8.1.0",
-    "grunt": "^1.0.4",
-    "grunt-babel": "^5.0.0",
-    "grunt-bg-shell": "^2.3.3",
-    "grunt-cli": "^1",
-    "grunt-contrib-clean": "^1",
-    "grunt-contrib-concat": "^1",
-    "grunt-contrib-connect": "^1",
-    "grunt-contrib-copy": "^1",
-    "grunt-contrib-requirejs": "^1",
-    "grunt-contrib-uglify": "^1",
-    "grunt-contrib-watch": "^1.1.0",
-    "grunt-webpack": "^1.0.8",
-    "husky": "^3.1.0",
-    "lint-staged": "^9.5.0",
-    "mocha": "^5",
-    "mock-stdin": "^0.3.0",
-    "mustache": "^2.1.3",
-    "nyc": "^14.1.1",
-    "prettier": "^1.19.1",
-    "semver": "^5.0.1",
-    "sinon": "^7.5.0",
-    "typescript": "^3.4.3",
-    "uglify-js": "^3.1.4",
-    "underscore": "^1.5.1",
-    "webpack": "^1.12.6",
-    "webpack-dev-server": "^1.12.1",
-    "coffeescript": "^2.6.1",
-  },
-  "main": "lib/index.js",
-  "types": "types/index.d.ts",
-  "browser": {
-    "./lib/index.js": "./dist/cjs/handlebars.js",
-    "./runtime": "./dist/cjs/handlebars.runtime.js"
-  },
-  "bin": {
-    "handlebars": "bin/handlebars.js"
-  },
-  "scripts": {
-    "build": "grunt build",
-    "format": "prettier --write '**/*.js' && eslint --fix .",
-    "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",
-    "lint:eslint": "eslint --max-warnings 0 .",
-    "lint:prettier": "prettier --check '**/*.js'",
-    "lint:types": "dtslint types",
-    "test": "npm run test:mocha",
-    "test:mocha": "grunt build && grunt test",
-    "test:browser": "playwright test --config tests/browser/playwright.config.js tests/browser/spec.js",
-    "test:integration": "grunt integration-tests",
-    "test:serve": "grunt connect:server:keepalive",
-    "extensive-tests-and-publish-to-aws": "npx mocha tasks/tests/ && grunt --stack extensive-tests-and-publish-to-aws",
-    "--- combined tasks ---": "",
-    "check-before-pull-request": "concurrently --kill-others-on-fail npm:lint npm:test"
-  },
-  "jspm": {
-    "main": "handlebars",
-    "directories": {
-      "lib": "dist/cjs"
-    },
-    "buildConfig": {
-      "minify": true
-    }
-  },
-  "files": [
-    "bin",
-    "dist/*.js",
-    "dist/amd/**/*.js",
-    "dist/cjs/**/*.js",
-    "lib",
-    "release-notes.md",
-    "runtime.js",
-    "types/*.d.ts",
-    "runtime.d.ts"
-  ],
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.{js,css,json}": [
-      "prettier --write",
-      "git add"
-    ],
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ]
-  }
+	"name": "handlebars",
+	"version": "5.0.0-alpha.1",
+	"description": "Handlebars provides the power necessary to let you build semantic templates effectively with no frustration",
+	"homepage": "https://www.handlebarsjs.com/",
+	"keywords": [
+		"handlebars",
+		"mustache",
+		"template",
+		"html"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/handlebars-lang/handlebars.js.git"
+	},
+	"author": "Yehuda Katz",
+	"license": "MIT",
+	"readmeFilename": "README.markdown",
+	"engines": {
+		"node": ">=10"
+	},
+	"dependencies": {
+		"@handlebars/parser": "^1.1.0",
+		"neo-async": "^2.6.2",
+		"source-map": "^0.6.1",
+		"yargs": "^16.2.0"
+	},
+	"peerDependencies": {
+		"uglify-js": "^3.1.4"
+	},
+	"devDependencies": {
+		"@definitelytyped/dtslint": "^0.0.100",
+		"@playwright/test": "^1.17.1",
+		"aws-sdk": "^2.1.49",
+		"babel-loader": "^5.0.0",
+		"babel-runtime": "^5.1.10",
+		"benchmark": "~1.0",
+		"chai": "^4.2.0",
+		"chai-diff": "^1.0.1",
+		"concurrently": "^5.0.0",
+		"dirty-chai": "^2.0.1",
+		"dustjs-linkedin": "^2.0.2",
+		"eslint": "^6.7.2",
+		"eslint-config-prettier": "^6.7.0",
+		"eslint-plugin-compat": "^3.13.0",
+		"eslint-plugin-es5": "^1.4.1",
+		"fs-extra": "^8.1.0",
+		"grunt": "^1.0.4",
+		"grunt-babel": "^5.0.0",
+		"grunt-bg-shell": "^2.3.3",
+		"grunt-cli": "^1",
+		"grunt-contrib-clean": "^1",
+		"grunt-contrib-concat": "^1",
+		"grunt-contrib-connect": "^1",
+		"grunt-contrib-copy": "^1",
+		"grunt-contrib-requirejs": "^1",
+		"grunt-contrib-uglify": "^1",
+		"grunt-contrib-watch": "^1.1.0",
+		"grunt-webpack": "^1.0.8",
+		"husky": "^3.1.0",
+		"lint-staged": "^9.5.0",
+		"mocha": "^5",
+		"mock-stdin": "^0.3.0",
+		"mustache": "^2.1.3",
+		"nyc": "^14.1.1",
+		"prettier": "^1.19.1",
+		"semver": "^5.0.1",
+		"sinon": "^7.5.0",
+		"typescript": "^3.4.3",
+		"uglify-js": "^3.1.4",
+		"underscore": "^1.5.1",
+		"webpack": "^1.12.6",
+		"webpack-dev-server": "^1.12.1"
+	},
+	"main": "lib/index.js",
+	"types": "types/index.d.ts",
+	"browser": {
+		"./lib/index.js": "./dist/cjs/handlebars.js",
+		"./runtime": "./dist/cjs/handlebars.runtime.js"
+	},
+	"bin": {
+		"handlebars": "bin/handlebars.js"
+	},
+	"scripts": {
+		"build": "grunt build",
+		"format": "prettier --write '**/*.js' && eslint --fix .",
+		"lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",
+		"lint:eslint": "eslint --max-warnings 0 .",
+		"lint:prettier": "prettier --check '**/*.js'",
+		"lint:types": "dtslint types",
+		"test": "npm run test:mocha",
+		"test:mocha": "grunt build && grunt test",
+		"test:browser": "playwright test --config tests/browser/playwright.config.js tests/browser/spec.js",
+		"test:integration": "grunt integration-tests",
+		"test:serve": "grunt connect:server:keepalive",
+		"extensive-tests-and-publish-to-aws": "npx mocha tasks/tests/ && grunt --stack extensive-tests-and-publish-to-aws",
+		"--- combined tasks ---": "",
+		"check-before-pull-request": "concurrently --kill-others-on-fail npm:lint npm:test"
+	},
+	"jspm": {
+		"main": "handlebars",
+		"directories": {
+			"lib": "dist/cjs"
+		},
+		"buildConfig": {
+			"minify": true
+		}
+	},
+	"files": [
+		"bin",
+		"dist/*.js",
+		"dist/amd/**/*.js",
+		"dist/cjs/**/*.js",
+		"lib",
+		"release-notes.md",
+		"runtime.js",
+		"types/*.d.ts",
+		"runtime.d.ts"
+	],
+	"husky": {
+		"hooks": {
+			"pre-commit": "lint-staged"
+		}
+	},
+	"lint-staged": {
+		"*.{js,css,json}": [
+			"prettier --write",
+			"git add"
+		],
+		"*.js": [
+			"eslint --fix",
+			"git add"
+		]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "handlebars": "bin/handlebars.js"
   },
   "scripts": {
-    "prepare": "npm i -D && npm run build",
     "build": "grunt build",
     "format": "prettier --write '**/*.js' && eslint --fix .",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "handlebars": "bin/handlebars.js"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "grunt build",
     "format": "prettier --write '**/*.js' && eslint --fix .",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",


### PR DESCRIPTION
Fixes https://github.com/handlebars-lang/handlebars.js/issues/1174

In webpack 5 things seem to have changed. From https://github.com/webpack/webpack/issues/15007 which itself is from https://github.com/facebook/create-react-app/issues/11756 the fs polyfills webpack used to include by default are no longer included. The browser wildcard '.' isn't valid according to https://github.com/webpack/webpack/issues/15007 and should refer to a full filepath. I've changed the config to be valid, and it seems to work as far as I can tell. There was also a missing coffeescript dev dependency which caused the grunt build to fail, I added this too.