### PR TITLE
Fix bundler issue with webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,10 +74,7 @@
   },
   "main": "lib/index.js",
   "types": "types/index.d.ts",
-  "browser": {
-    ".": "./dist/cjs/handlebars.js",
-    "./runtime": "./dist/cjs/handlebars.runtime.js"
-  },
+  "browser": "./dist/cjs/handlebars.js",
   "bin": {
     "handlebars": "bin/handlebars.js"
   },

--- a/tests/integration/webpack-test/package.json
+++ b/tests/integration/webpack-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-test",
-  "description": "Various tests with Handlebars and Webpack",
+  "description": "Various tests with Handlebars and multiple webpack versions",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -8,14 +8,8 @@
     "test": "node dist/main.js"
   },
   "private": true,
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "handlebars": "file:../../..",
-    "handlebars-loader": "^1.7.1",
-    "webpack": "^4.39.3",
-    "webpack-cli": "^3.3.7"
+    "handlebars-loader": "^1.7.1"
   }
 }

--- a/tests/integration/webpack-test/src/handlebars-esm-import-test.js
+++ b/tests/integration/webpack-test/src/handlebars-esm-import-test.js
@@ -1,0 +1,5 @@
+import Handlebars from 'handlebars/lib/handlebars';
+import { assertEquals } from './lib/assert';
+
+const template = Handlebars.compile('Author: {{author}}');
+assertEquals(template({ author: 'Yehuda' }), 'Author: Yehuda');

--- a/tests/integration/webpack-test/src/handlebars-runtime-test.js
+++ b/tests/integration/webpack-test/src/handlebars-runtime-test.js
@@ -1,0 +1,43 @@
+import * as Handlebars from 'handlebars/runtime';
+import { assertEquals } from './lib/assert';
+
+const template = Handlebars.template({
+  compiler: [8, '>= 4.3.0'],
+  main: function(container, depth0, helpers, partials, data) {
+    var helper,
+      lookupProperty =
+        container.lookupProperty ||
+        function(parent, propertyName) {
+          if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
+            return parent[propertyName];
+          }
+          return undefined;
+        };
+
+    return (
+      'Author: ' +
+      container.escapeExpression(
+        ((helper =
+          (helper =
+            lookupProperty(helpers, 'author') ||
+            (depth0 != null ? lookupProperty(depth0, 'author') : depth0)) !=
+          null
+            ? helper
+            : container.hooks.helperMissing),
+        typeof helper === 'function'
+          ? helper.call(depth0 != null ? depth0 : container.nullContext || {}, {
+              name: 'author',
+              hash: {},
+              data: data,
+              loc: {
+                start: { line: 1, column: 8 },
+                end: { line: 1, column: 18 }
+              }
+            })
+          : helper)
+      )
+    );
+  },
+  useData: true
+});
+assertEquals(template({ author: 'Yehuda' }), 'Author: Yehuda');

--- a/tests/integration/webpack-test/test.sh
+++ b/tests/integration/webpack-test/test.sh
@@ -2,15 +2,26 @@
 
 set -e
 
+run_tests () {
+  for i in dist/*-test.js ; do
+    echo "----------------------"
+    echo "-- Running $i"
+    echo "----------------------"
+    node "$i"
+    echo "Success"
+  done
+}
+
 # Cleanup: package-lock and "npm ci" is not working with local dependencies
 rm dist package-lock.json -rf
 npm install --legacy-peer-deps
-npm run build
 
-for i in dist/*-test.js ; do
-  echo "----------------------"
-  echo "-- Running $i"
-  echo "----------------------"
-  node "$i"
-  echo "Success"
-done
+# Test with webpack 4
+npm install --legacy-peer-deps --no-save webpack@^4 webpack-cli@^3
+npm run build
+run_tests
+
+# Test with webpack 5
+npm install --legacy-peer-deps --no-save webpack@^5 webpack-cli@^4
+npm run build
+run_tests


### PR DESCRIPTION
As explained in issue #1844 and in issue
https://github.com/webpack/webpack/issues/15007#issuecomment-996615250,
the way we used the `browser`-field was wrong.

The main reason for using the `browser`-field is the requirement of
`require('fs')` in the main-entry-file.
The workaround for this was using `require('handlebars/lib/handlebars')`,
but now it will also work via `require('handlebars')` for bundlers that
respect the `browser`-field.

The `"./runtime"`-config was removed, because it didn't have any effect.
In order to detect regressions, the webpack-integration test was
extended to test with different webpack versions.

Fixes #1174
Closes #1844

* [ ] Backport to 4.x as soon as merged