### PR TITLE
Fix for when `global` and `window` object both not found.

### DIFF
--- a/lib/handlebars/no-conflict.js
+++ b/lib/handlebars/no-conflict.js
@@ -1,12 +1,22 @@
-/* global global, window */
+/* global globalThis */
 export default function(Handlebars) {
   /* istanbul ignore next */
-  let root = typeof global !== 'undefined' ? global : window,
-    $Handlebars = root.Handlebars;
+  // https://mathiasbynens.be/notes/globalthis
+  (function() {
+    if (typeof globalThis === 'object') return;
+    Object.prototype.__defineGetter__('__magic__', function() {
+      return this;
+    });
+    __magic__.globalThis = __magic__; // eslint-disable-line no-undef
+    delete Object.prototype.__magic__;
+  })();
+
+  const $Handlebars = globalThis.Handlebars;
+
   /* istanbul ignore next */
   Handlebars.noConflict = function() {
-    if (root.Handlebars === Handlebars) {
-      root.Handlebars = $Handlebars;
+    if (globalThis.Handlebars === Handlebars) {
+      globalThis.Handlebars = $Handlebars;
     }
     return Handlebars;
   };


### PR DESCRIPTION
When using Handlebars in a Cloudflare Worker, an environment in which the `window` and `global` objects both don't exist, an error is thrown about `window` being undefined.

In this PR I have slightly changed the code so that if both window and global do not exist, a Handlebars.noConflict function is generated that just returns the original `Handlebars` instance.
