### PR TITLE
added _parent and context to data returned by #with in helpers #1840

### DIFF
--- a/lib/handlebars/helpers/with.js
+++ b/lib/handlebars/helpers/with.js
@@ -1,5 +1,5 @@
 import { Exception } from '@handlebars/parser';
-import { isEmpty, isFunction } from '../utils';
+import { createFrame, isEmpty, isFunction } from '../utils';
 
 export default function (instance) {
   instance.registerHelper('with', function (context, options) {
@@ -13,7 +13,11 @@ export default function (instance) {
     let fn = options.fn;
 
     if (!isEmpty(context)) {
-      let data = options.data;
+      let data = createFrame(options.data);
+
+      if (data) {
+        data.key = context;
+      }
 
       return fn(context, {
         data: data,


### PR DESCRIPTION
This is a fix to solve Issue 1840. Resolves https://github.com/handlebars-lang/handlebars.js/issues/1840. Added _parent and context to data returned by with in helpers just like each does to each iterated field. 
I just couldn't find where and how should I add tests for this functionality, i would be glad if you help me with that. 
thanks!