### PR TITLE
added a helper to check if a partial is defined in the context #1948

### DIFF
--- a/lib/handlebars/helpers.js
+++ b/lib/handlebars/helpers.js
@@ -5,6 +5,7 @@ import registerIf from './helpers/if';
 import registerLog from './helpers/log';
 import registerLookup from './helpers/lookup';
 import registerWith from './helpers/with';
+import registerPartialDefined from './helpers/partial-defined'
 
 export function registerDefaultHelpers(instance) {
   registerBlockHelperMissing(instance);
@@ -14,6 +15,7 @@ export function registerDefaultHelpers(instance) {
   registerLog(instance);
   registerLookup(instance);
   registerWith(instance);
+  registerPartialDefined(instance);
 }
 
 export function moveHelperToHooks(instance, helperName, keepHelper) {

--- a/lib/handlebars/helpers/partial-defined.js
+++ b/lib/handlebars/helpers/partial-defined.js
@@ -1,0 +1,16 @@
+import { Exception } from '@handlebars/parser';
+
+export default function (instance) {
+  instance.registerHelper('partialDefined', function (partialName, options) {
+    if (arguments.length != 2) {
+      throw new Exception('#partialDefined requires exactly one argument');
+    }
+    
+    if (instance.partials[partialName] === undefined) {
+        return false
+    } else {
+        return true
+    }
+
+  });
+}


### PR DESCRIPTION
This is a fix to solve Issue 1948. Resolves https://github.com/handlebars-lang/handlebars.js/issues/1948. Added a new helper called partialDefined which checks the current context for given partial existence. 