### PR TITLE
Allow using strict and compat together #1741

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -116,7 +116,7 @@ export function template(templateSpec, env) {
   // Just add water
   let container = {
     strict: function (obj, name, loc) {
-      if (!obj || !(name in obj)) {
+      if (!obj || (typeof obj === 'object' && !(name in obj))) {
         throw new Exception('"' + name + '" not defined in ' + obj, {
           loc: loc,
         });

--- a/spec/strict.js
+++ b/spec/strict.js
@@ -48,7 +48,6 @@ describe('strict', function () {
       });
 
       xt.toThrow(Error);
-
       xt.withRuntimeOptions({ data: { hello: 'foo' } }).toCompileTo('foo');
     });
 
@@ -87,9 +86,7 @@ describe('strict', function () {
 
     it('should allow undefined hash when passed to helpers', function () {
       expectTemplate('{{helper value=@foo}}')
-        .withCompileOptions({
-          strict: true,
-        })
+        .withCompileOptions({ strict: true })
         .withHelpers({
           helper: function (options) {
             equals('value' in options.hash, true);
@@ -98,6 +95,13 @@ describe('strict', function () {
           },
         })
         .toCompileTo('success');
+    });
+
+    it('should allow compat-mode combined with strict-mode', function () {
+      expectTemplate('Foo {{bar}}')
+        .withCompileOptions({ compat: true, strict: true })
+        .withInput({ bar: 'baz' })
+        .toCompileTo('Foo baz');
     });
 
     it('should show error location on missing property lookup', function () {


### PR DESCRIPTION
This is a fix to solve Issue 1741. Resolves https://github.com/handlebars-lang/handlebars.js/issues/1741. just checked if obj is really an object at the errors occurrence line specified in the issue. I hope it helps. 