### PR TITLE
Fix #1748 where allowed prototype methods are not called

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -133,6 +133,9 @@ export function template(templateSpec, env) {
       }
 
       if (resultIsAllowed(result, container.protoAccessControl, propertyName)) {
+        if (typeof result === 'function') {
+          return parent[propertyName]();
+        }
         return result;
       }
       return undefined;

--- a/spec/security.js
+++ b/spec/security.js
@@ -285,6 +285,17 @@ describe('security issues', function () {
           })
           .toCompileTo('abc');
       });
+
+      it('should use a proto method to trim a string', function () {
+        expectTemplate('{{aString.trim}}')
+          .withInput({ aString: '  abc  ' })
+          .withRuntimeOptions({
+            allowedProtoMethods: {
+              trim: true,
+            },
+          })
+          .toCompileTo('abc');
+      });
     });
 
     describe('control access to prototype non-methods via "allowedProtoProperties" and "allowProtoPropertiesByDefault', function () {


### PR DESCRIPTION
Fixes #1748 where allowed prototype methods are not called.

Without this fix [the official documentation is incorrect](https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access):

```js
const template = handlebars.compile("{{aString.trim}}");
const result = template(
  { aString: "  abc  " },
  {
    allowedProtoMethods: {
      trim: true
    }
  }
);
// result = 'abc'
```

The result is `[object Object]`, not `abc`.