### PR TITLE
Publish `latest` and `tags` to AWS S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  publish-aws-s3:
+    name: Publish to AWS S3
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish
+        run: npm run publish:aws
+        env:
+          # Note: the environment secrets `S3_ACCESS_KEY_ID`
+          #       and `S3_SECRET_ACCESS_KEY` have to be set!
+          S3_BUCKET_NAME: "builds.handlebarsjs.com"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -156,14 +156,6 @@ module.exports = function (grunt) {
     'copy:components',
   ]);
 
-  // Requires secret properties from .travis.yaml
-  grunt.registerTask('extensive-tests-and-publish-to-aws', [
-    'default',
-    'shell:integrationTests',
-    'metrics',
-    'publish-to-aws',
-  ]);
-
   grunt.registerTask('on-file-change', ['build', 'concat:tests', 'test']);
 
   // === Primary tasks ===

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
   },
   "scripts": {
     "build": "grunt build",
+    "release": "grunt release",
+    "publish:aws": "npm run test:tasks && grunt && grunt publish-to-aws",
     "format": "prettier --write '**/*.js' && eslint --fix .",
     "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",
     "lint:eslint": "eslint --max-warnings 0 .",
@@ -86,10 +88,10 @@
     "lint:types": "dtslint types",
     "test": "npm run test:mocha",
     "test:mocha": "grunt build && grunt test",
+    "test:tasks": "mocha tasks/tests/",
     "test:browser": "playwright test --config tests/browser/playwright.config.js",
     "test:integration": "grunt integration-tests",
     "test:serve": "grunt connect:server:keepalive",
-    "extensive-tests-and-publish-to-aws": "npx mocha tasks/tests/ && grunt --stack extensive-tests-and-publish-to-aws",
     "--- combined tasks ---": "",
     "check-before-pull-request": "concurrently --kill-others-on-fail npm:lint npm:test"
   },


### PR DESCRIPTION
This recreates the logic from this removed TravisCI job:

https://github.com/handlebars-lang/handlebars.js/blob/a9a8e403213583ca90cb7c872d3a22796c37d961/.travis.yml#L16-L25