### PR TITLE
Checkout submodules when publishing to AWS S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          submodules: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Fixes the following error:

```
Running env: ./runtime
node:internal/fs/utils:350
    throw err;
    ^

Error: ENOENT: no such file or directory, scandir '/home/runner/work/handlebars.js/handlebars.js/spec/mustache/specs/'
```

See #1972