### PR TITLE
update package-lock.json to correct version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "handlebars",
-  "version": "4.7.7",
+  "version": "4.7.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "handlebars",
-      "version": "4.7.7",
+      "version": "4.7.8",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",


### PR DESCRIPTION
This updates package-lock.json to 4.7.8, which seems not to be done automatically