### PR TITLE
refactor: rename i to startPartIndex

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -535,16 +535,22 @@ JavaScriptCompiler.prototype = {
     this.resolvePath('data', parts, 0, true, strict);
   },
 
-  resolvePath: function(type, parts, i, falsy, strict) {
+  resolvePath: function(type, parts, startPartIndex, falsy, strict) {
     if (this.options.strict || this.options.assumeObjects) {
       this.push(
-        strictLookup(this.options.strict && strict, this, parts, i, type)
+        strictLookup(
+          this.options.strict && strict,
+          this,
+          parts,
+          startPartIndex,
+          type
+        )
       );
       return;
     }
 
     let len = parts.length;
-    for (; i < len; i++) {
+    for (let i = startPartIndex; i < len; i++) {
       /* eslint-disable no-loop-func */
       this.replaceStack(current => {
         let lookup = this.nameLookup(current, parts[i], type);
@@ -1263,14 +1269,14 @@ JavaScriptCompiler.isValidJavaScriptVariableName = function(name) {
   );
 };
 
-function strictLookup(requireTerminal, compiler, parts, i, type) {
+function strictLookup(requireTerminal, compiler, parts, startPartIndex, type) {
   let stack = compiler.popStack(),
     len = parts.length;
   if (requireTerminal) {
     len--;
   }
 
-  for (; i < len; i++) {
+  for (let i = startPartIndex; i < len; i++) {
     stack = compiler.nameLookup(stack, parts[i], type);
   }
 
@@ -1280,7 +1286,7 @@ function strictLookup(requireTerminal, compiler, parts, i, type) {
       '(',
       stack,
       ', ',
-      compiler.quotedString(parts[i]),
+      compiler.quotedString(parts[len]),
       ', ',
       JSON.stringify(compiler.source.currentLocation),
       ' )'


### PR DESCRIPTION
As said in #1966 I renamed "i" to "startPartIndex", which is maybe a little more helpful.
Minor additional changes it the use of "i" only within the for-loops and the use of "len" instead of "i" after the loop.

"i" and "len" should always be equal in this case.