### PR TITLE
Reduce helper overhead

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -445,6 +445,7 @@ function wrapHelpersToPassLookupProperty(mergedHelpers, container) {
 function passLookupPropertyOption(helper, container) {
   const lookupProperty = container.lookupProperty;
   return wrapHelper(helper, options => {
-    return Utils.extend({ lookupProperty }, options);
+    options.lookupProperty = lookupProperty;
+    return options;
   });
 }


### PR DESCRIPTION
This results in about a 30% improvement in a helper-heavy template. `Utils.extend` is expensive to use in any hot path.