### PR TITLE
chore(pull-request-template): correct types path

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,6 @@ Generally we like to see pull requests that
 - [ ] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
 - [ ] Have good commit messages
 - [ ] Have tests
-- [ ] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (lib/handlebars.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
+- [ ] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (types/index.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
 - [ ] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
 - [ ] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR.


### PR DESCRIPTION
I think it's `/types` now.
