### PR TITLE
Fix running integration tests on macOS

### DIFF
--- a/tests/integration/multi-nodejs-test/test.sh
+++ b/tests/integration/multi-nodejs-test/test.sh
@@ -16,7 +16,7 @@ unset npm_config_prefix
 echo "Handlebars should be able to run in various versions of NodeJS"
 for node_version_to_test in 12 14 16 18; do
 
-    rm target node_modules package-lock.json -rf
+    rm -rf target node_modules package-lock.json
     mkdir target
 
     nvm install "$node_version_to_test"

--- a/tests/integration/rollup-test/test.sh
+++ b/tests/integration/rollup-test/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Cleanup: package-lock and "npm ci" is not working with local dependencies
-rm dist package-lock.json -rf
+rm -rf dist package-lock.json
 npm install
 npm run build
 

--- a/tests/integration/webpack-babel-test/test.sh
+++ b/tests/integration/webpack-babel-test/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Cleanup: package-lock and "npm ci" is not working with local dependencies
-rm dist package-lock.json -rf
+rm -rf dist package-lock.json
 npm install --legacy-peer-deps
 npm run build
 

--- a/tests/integration/webpack-test/test.sh
+++ b/tests/integration/webpack-test/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Cleanup: package-lock and "npm ci" is not working with local dependencies
-rm dist package-lock.json -rf
+rm -rf dist package-lock.json
 npm install --legacy-peer-deps
 npm run build
 


### PR DESCRIPTION
macOS/BSD does not support flags after arguments.