### PR TITLE
Drop support for EOL Node.js versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,31 +25,6 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  dependencies:
-    name: Test (dependencies)
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          # Node 14 ships with npm v6, which doesn't install peer-dependencies by default.
-          # Starting with npm v7 (which is shipped with Node >= 16), peer-dependencies are
-          # automatically installed. So this test (check for unmet peer-dependencies) only
-          # works with Node <= 14.
-          node-version: '14'
-
-      # Simulate an installation by a dependent package
-      - name: Install dependencies
-        run: |
-          rm package-lock.json
-          npm install --production
-
-      - name: Check dependency tree
-        run: npm ls
-
   test:
     name: Test (Node)
     runs-on: ${{ matrix.operating-system }}
@@ -58,7 +33,7 @@ jobs:
       matrix:
         operating-system: ['ubuntu-latest', 'windows-latest']
         # https://nodejs.org/en/about/releases/
-        node-version: ['12', '14', '16', '18', '20']
+        node-version: ['18', '20']
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "readmeFilename": "README.markdown",
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "dependencies": {
     "@handlebars/parser": "^2.1.0",

--- a/tests/integration/multi-nodejs-test/test.sh
+++ b/tests/integration/multi-nodejs-test/test.sh
@@ -14,7 +14,7 @@ cd "$( dirname "$( readlink -f "$0" )" )" || exit 1
 unset npm_config_prefix
 
 echo "Handlebars should be able to run in various versions of NodeJS"
-for node_version_to_test in 12 14 16 18; do
+for node_version_to_test in 18 20; do
 
     rm target node_modules package-lock.json -rf
     mkdir target


### PR DESCRIPTION
This will be needed if ESM support is added and simplifies things.