### PR TITLE
Revert "Improve partial indenting performance"

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -89,8 +89,15 @@ export function template(templateSpec, env) {
     }
     if (result != null) {
       if (options.indent) {
-        result =
-          options.indent + result.replace(/\n(?!$)/g, '\n' + options.indent);
+        let lines = result.split('\n');
+        for (let i = 0, l = lines.length; i < l; i++) {
+          if (!lines[i] && i + 1 === l) {
+            break;
+          }
+
+          lines[i] = options.indent + lines[i];
+        }
+        result = lines.join('\n');
       }
       return result;
     } else {


### PR DESCRIPTION
This reverts commit 08fddee0331cd52b82ced243dee2f0318600414f.

The change caused performance regressions in some cases and performance was not consistent across engines.