### PR TITLE
Do not use `declare module` in first-party type declarations

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -288,11 +288,6 @@ export interface Logger {
 
 export type CompilerInfo = [number /* revision */, string /* versions */];
 
-declare module 'handlebars/runtime' {
-  const runtime: typeof Handlebars;
-  export default runtime;
-}
-
 // Named exports matching lib/index.js for ESM/CJS interop
 export const create: typeof Handlebars.create;
 export const compile: typeof Handlebars.compile;


### PR DESCRIPTION
First-party type declarations should simply be provided at top level in .d.ts files with the right filenames.

The `declare module` was breaking usage like `import "handlebars/runtime.js"` (which happens to be the only way to import the runtime from a project with native ES modules, `"type": "module"`).

- Corresponding PR for 4.x: #2053