### PR TITLE
fix README links to docs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,7 +17,7 @@ Checkout the official Handlebars docs site at
 Installing
 ----------
 
-See our [installation documentation](https://handlebarsjs.com/installation/).
+See our [installation documentation](https://handlebarsjs.com/guide/installation/).
 
 Usage
 -----
@@ -52,7 +52,7 @@ Full documentation and more examples are at [handlebarsjs.com](https://handlebar
 Precompiling Templates
 ----------------------
 
-Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](https://handlebarsjs.com/installation/precompilation.html).
+Handlebars allows templates to be precompiled and included as javascript code rather than the handlebars template allowing for faster startup time. Full details are located [here](https://handlebarsjs.com/guide/installation/precompilation.html).
 
 Differences Between Handlebars.js and Mustache
 ----------------------------------------------


### PR DESCRIPTION
Fixed 2 links in the README to the docs website.

I just went ahead and clicked all links and found that the link to the independent performance benchmark mustache vs handlebars is down:  
http://sorescode.com/2010/09/12/benchmarks.html  
I was unable to find it anywhere else on the web.

----


Before creating a pull-request, please check https://github.com/handlebars-lang/handlebars.js/blob/master/CONTRIBUTING.md first.

Generally we like to see pull requests that

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (types/index.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Currently, the `4.x`-branch contains the latest version. Please target that branch in the PR.
