### PR TITLE
fix(cli): handle directories with no matching templates

### DIFF
--- a/bin/handlebars.js
+++ b/bin/handlebars.js
@@ -102,7 +102,10 @@ loadTemplates(argv, function (err, opts) {
     throw err;
   }
 
-  if (opts.help || (!opts.templates.length && !opts.version)) {
+  if (
+    opts.help ||
+    (!opts.templates.length && !opts.hasDirectory && !opts.version)
+  ) {
     parser.showHelp('log');
   } else {
     // cli() is async (returns a Promise), so errors would become unhandled

--- a/lib/precompiler.js
+++ b/lib/precompiler.js
@@ -164,6 +164,17 @@ export async function cli(opts) {
     );
   }
 
+  if (!opts.templates.length && opts.hasDirectory) {
+    const directories =
+      (opts.files && opts.files.length && opts.files.join(', ')) ||
+      'the specified directory';
+    const extension = opts.extension || 'handlebars';
+    console.warn(
+      `Warning: No files matching *.${extension} found under ${directories}. Pass --extension <ext> if your templates use a different extension.`
+    );
+    return;
+  }
+
   if (opts.simple && opts.min) {
     throw new Handlebars.Exception('Unable to minimize simple output');
   }

--- a/spec/precompiler.js
+++ b/spec/precompiler.js
@@ -16,6 +16,8 @@ describe('precompiler', function () {
 
   var log,
     logFunction,
+    warnLog,
+    warnLogFunction,
     errorLog,
     errorLogFunction,
     precompile,
@@ -40,6 +42,11 @@ describe('precompiler', function () {
     console.log = function () {
       log += Array.prototype.join.call(arguments, '');
     };
+    warnLogFunction = console.warn;
+    warnLog = '';
+    console.warn = function () {
+      warnLog += Array.prototype.join.call(arguments, '');
+    };
     errorLogFunction = console.error;
     errorLog = '';
     console.error = function () {
@@ -56,6 +63,7 @@ describe('precompiler', function () {
     uglify.minify = minify;
     fs.writeFileSync = writeFileSync;
     console.log = logFunction;
+    console.warn = warnLogFunction;
     console.error = errorLogFunction;
   });
 
@@ -68,12 +76,23 @@ describe('precompiler', function () {
       'Must define at least one template or directory.'
     );
   });
-  it('should handle empty/filtered directories', async function () {
+  it('should warn and stop when directories contain no matching templates', async function () {
     Handlebars.precompile = function () {
       return 'simple';
     };
-    await Precompiler.cli({ hasDirectory: true, templates: [] });
-    // Success is not throwing
+    await Precompiler.cli({
+      hasDirectory: true,
+      templates: [],
+      files: ['spec/artifacts'],
+      extension: 'handlebars',
+      output: 'ignored.js',
+    });
+
+    expect(warnLog).toBe(
+      'Warning: No files matching *.handlebars found under spec/artifacts. Pass --extension <ext> if your templates use a different extension.'
+    );
+    expect(file).toBe(undefined);
+    expect(log).toBe('');
   });
   it('should throw when combining simple and minimized', async function () {
     await expect(


### PR DESCRIPTION
Fixes #2109

Previously, when passing a directory to the handlebars CLI that either had no template files or no files matching the extension, the CLI would show the help message instead of processing the directory.

This fix:
1. Updates the help condition to also check hasDirectory flag  
2. Adds a warning when a directory is specified but no templates are found

The CLI now properly processes directories and provides feedback when no templates are found instead of confusingly showing usage help.

## Changes
- `bin/handlebars.mjs`: Added `!opts.hasDirectory` to the help condition
- `lib/precompiler.js`: Added warning when directory has no matching templates

## Testing
- Tested with empty directories
- Tested with directories containing templates  
- Tested with directories containing no matching files
- All existing unit tests pass