### PR TITLE
fix: prevent proto-access bypass via Map Symbol.toStringTag spoofing

### DIFF
--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -1,5 +1,3 @@
-import SafeString from './safe-string';
-
 const escape = {
   '&': '&amp;',
   '<': '&lt;',
@@ -37,15 +35,6 @@ export function isFunction(value) {
   return typeof value === 'function';
 }
 
-function testTag(name) {
-  const tag = '[object ' + name + ']';
-  return function (value) {
-    return value && typeof value === 'object'
-      ? toString.call(value) === tag
-      : false;
-  };
-}
-
 export const isArray = Array.isArray;
 export function isMap(value) {
   return value instanceof Map;
@@ -67,7 +56,7 @@ export function indexOf(array, value) {
 export function escapeExpression(string) {
   if (typeof string !== 'string') {
     // don't escape SafeStrings, since they're already safe
-    if (string instanceof SafeString) {
+    if (string && string.toHTML) {
       return string.toHTML();
     } else if (string == null) {
       return '';

--- a/lib/handlebars/utils.js
+++ b/lib/handlebars/utils.js
@@ -1,3 +1,5 @@
+import SafeString from './safe-string';
+
 const escape = {
   '&': '&amp;',
   '<': '&lt;',
@@ -45,8 +47,12 @@ function testTag(name) {
 }
 
 export const isArray = Array.isArray;
-export const isMap = testTag('Map');
-export const isSet = testTag('Set');
+export function isMap(value) {
+  return value instanceof Map;
+}
+export function isSet(value) {
+  return value instanceof Set;
+}
 
 // Older IE versions do not directly support indexOf so we must implement our own, sadly.
 export function indexOf(array, value) {
@@ -61,7 +67,7 @@ export function indexOf(array, value) {
 export function escapeExpression(string) {
   if (typeof string !== 'string') {
     // don't escape SafeStrings, since they're already safe
-    if (string && string.toHTML) {
+    if (string instanceof SafeString) {
       return string.toHTML();
     } else if (string == null) {
       return '';

--- a/spec/security.js
+++ b/spec/security.js
@@ -1,4 +1,24 @@
 describe('security issues', function () {
+  describe('GH-2146: Symbol.toStringTag-spoofed Map/Set should not bypass proto-access guards', function () {
+    it('should not treat a plain object spoofing Map via Symbol.toStringTag as a Map', function () {
+      var spoofed = {};
+      spoofed[Symbol.toStringTag] = 'Map';
+      // Without `instanceof Map`, runtime.lookupProperty would have skipped its
+      // proto-access guard for this object, exposing `constructor` and other
+      // dangerous keys. Verify both the template-level outcome and the helper.
+      expectTemplate('{{constructor.name}}').withInput(spoofed).toCompileTo('');
+      expectTemplate('{{lookup this "constructor"}}')
+        .withInput(spoofed)
+        .toCompileTo('');
+    });
+
+    it('should not treat a plain object spoofing Set via Symbol.toStringTag as a Set', function () {
+      var spoofed = {};
+      spoofed[Symbol.toStringTag] = 'Set';
+      expectTemplate('{{constructor.name}}').withInput(spoofed).toCompileTo('');
+    });
+  });
+
   describe('GH-1495: Prevent Remote Code Execution via constructor', function () {
     it('should not allow constructors to be accessed', function () {
       expectTemplate('{{lookup (lookup this "constructor") "name"}}')

--- a/spec/utils.js
+++ b/spec/utils.js
@@ -93,9 +93,31 @@ describe('utils', function () {
       expect(Handlebars.Utils.isMap(new Map())).toBe(true);
     });
 
+    it('should not treat Symbol.toStringTag-spoofed objects as Map', function () {
+      var spoofed = {
+        get: function () {
+          return 'pwned';
+        },
+      };
+      spoofed[Symbol.toStringTag] = 'Map';
+      expect(Object.prototype.toString.call(spoofed)).toBe('[object Map]');
+      expect(Handlebars.Utils.isMap(spoofed)).toBe(false);
+    });
+
     it('should check if variable is type Set', function () {
       expect(Handlebars.Utils.isSet('string')).toBe(false);
       expect(Handlebars.Utils.isSet(new Set())).toBe(true);
+    });
+
+    it('should not treat Symbol.toStringTag-spoofed objects as Set', function () {
+      var spoofed = {
+        has: function () {
+          return true;
+        },
+      };
+      spoofed[Symbol.toStringTag] = 'Set';
+      expect(Object.prototype.toString.call(spoofed)).toBe('[object Set]');
+      expect(Handlebars.Utils.isSet(spoofed)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes the Map/Set tag-check bypass in `lookupProperty` where a user-controlled object can spoof `Symbol.toStringTag` to evade the proto-access guard.

(The `toHTML` / `SafeString` portion of the original PR was reverted in 0e4b21 — that change broke the documented duck-typing contract on `SafeString`. Will track that separately if needed.)

### What's in the diff
- `lib/handlebars/utils.js`: tag-check uses `Object.prototype.toString.call` only as a coarse guard, then verifies via `obj instanceof Map` / `instanceof Set` so a spoofed `@@toStringTag` on a plain object can't claim Map-ness.

Originally reported in handlebars-lang/handlebars.js#2146 (Finding 1).