### PR TITLE
Fix explicit null value handling in compat mode

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -117,20 +117,10 @@ export function template(templateSpec, env) {
       return container.lookupProperty(obj, name);
     },
     strictLookup: function (depths, name, loc) {
-      const len = depths.length;
-      let depth;
-      for (let i = 0; i < len; i++) {
-        const d = depths[i];
-        if (
-          d &&
-          (typeof d === 'object' || typeof d === 'function') &&
-          name in d
-        ) {
-          depth = d;
-          break;
-        }
-      }
-      return container.strict(depth, name, loc);
+      const result = container.lookup(depths, name);
+      return result !== undefined
+        ? result
+        : container.strict(undefined, name, loc);
     },
     lookupProperty: function (parent, propertyName) {
       if (Utils.isMap(parent)) {
@@ -153,9 +143,17 @@ export function template(templateSpec, env) {
     lookup: function (depths, name) {
       const len = depths.length;
       for (let i = 0; i < len; i++) {
-        let result = depths[i] && container.lookupProperty(depths[i], name);
-        if (result != null) {
-          return depths[i][name];
+        const d = depths[i];
+        if (d == null) continue;
+        if (typeof d === 'object' || typeof d === 'function') {
+          if (Utils.isMap(d) ? d.has(name) : name in d) {
+            return container.lookupProperty(d, name);
+          }
+        } else {
+          const result = container.lookupProperty(d, name);
+          if (result != null) {
+            return result;
+          }
         }
       }
     },

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -388,6 +388,18 @@ describe('basic context', function () {
       .toCompileTo('Goodbye beautiful world!');
   });
 
+  it('compat mode resolves Map values through depthed lookup', function () {
+    expectTemplate('{{#with nested}}{{value}}/{{constructor}}{{/with}}')
+      .withInput({
+        nested: new Map([
+          ['value', 'map-value'],
+          ['constructor', 'map-constructor'],
+        ]),
+      })
+      .withCompileOptions({ compat: true })
+      .toCompileTo('map-value/map-constructor');
+  });
+
   it('nested paths with empty string value', function () {
     expectTemplate('Goodbye {{alan/expression}} world!')
       .withInput({ alan: { expression: '' } })

--- a/spec/blocks.js
+++ b/spec/blocks.js
@@ -259,6 +259,13 @@ describe('blocks', function () {
   });
 
   describe('compat mode', function () {
+    it('should directly return an explicitly null property', function () {
+      expectTemplate('{{#each items}}{{name}}{{/each}}')
+        .withCompileOptions({ compat: true })
+        .withInput({ name: 'root', items: [{ name: null }] })
+        .toCompileTo('');
+    });
+
     it('block with deep recursive lookup lookup', function () {
       expectTemplate(
         '{{#outer}}Goodbye {{#inner}}cruel {{omg}}{{/inner}}{{/outer}}'

--- a/spec/security.js
+++ b/spec/security.js
@@ -302,6 +302,16 @@ describe('security issues', function () {
           })
           .toCompileTo('abc');
       });
+
+      it('should not cause recursive lookup if allowed through options(in "compat+strict" mode)', function () {
+        expectTemplate('{{#aString}}{{trim}}{{/aString}}')
+          .withInput({ aString: '  abc  ', trim: 'trim' })
+          .withCompileOptions({ compat: true, strict: true })
+          .withRuntimeOptions({
+            allowedProtoMethods: { trim: true },
+          })
+          .toCompileTo('abc');
+      });
     });
 
     describe('control access to prototype non-methods via "allowedProtoProperties" and "allowProtoPropertiesByDefault', function () {

--- a/spec/strict.js
+++ b/spec/strict.js
@@ -166,7 +166,7 @@ describe('strict', function () {
     it('should still perform recursive lookup with a multi-part path not in context', function () {
       expectTemplate('{{#with child}}{{name.first}}{{/with}}')
         .withCompileOptions({ strict: true, compat: true })
-        .withInput({ name: { first: 'root' }, child: { name: null } })
+        .withInput({ name: { first: 'root' }, child: { x: 'y' } })
         .toCompileTo('root');
     });
 


### PR DESCRIPTION
Follow-up to GH-2150.

`container.lookup` used `result != null` which caused explicit null values to fall through to parent contexts. This was inconsistent with expected behavior and with Mustache, which stops and returns a key when present in the object, regardless of its value. The whole point of `compat` mode is to match Mustache's lookup semantics, so I don't think this behavior was intended.

There were no tests for `compat` with an explicit null value, apart from a couple `compat` + `strict` mode tests I just added myself in GH-2150. One of these tests ("should still perform recursive lookup with a multi-part path not in context") was inconsistent with the test immediately below it ("should directly return an explicitly null property"), and that is fixed here.

This change makes it possible for unify the lookup logic in `container.lookup` and `container.strictLookup`, additionally fixing an issue where `strictLookup` didn't respect the `allowedProtoMethods` runtime option the same as `lookup` (see the added test in `spec/security.js` compared to the test above it).

Also fixed compat mode `Map` value resolution, and included the test for it from #2156 (if that is merged first, I can rebase this to fix the merge conflict).