### PR TITLE
Fix Map each block param values

### DIFF
--- a/lib/handlebars/helpers/each.js
+++ b/lib/handlebars/helpers/each.js
@@ -33,7 +33,7 @@ export default function (instance) {
         ret +
         fn(value, {
           data: data,
-          blockParams: [context[field], field],
+          blockParams: [value, field],
         });
     }
 

--- a/spec/builtins.js
+++ b/spec/builtins.js
@@ -528,6 +528,22 @@ describe('builtin helpers', function () {
         .toCompileTo('not-in-each');
     });
 
+    it('each on Map should expose actual entry values as block params', function () {
+      var map = new Map([
+        ['constructor', 'constructor-value'],
+        ['toString', 'toString-value'],
+        ['normal', 'normal-value'],
+      ]);
+
+      expectTemplate('{{#each map as |value key|}}{{key}}={{value}};{{/each}}')
+        .withInput({ map: map })
+        .toCompileTo(
+          'constructor=constructor-value;' +
+            'toString=toString-value;' +
+            'normal=normal-value;'
+        );
+    });
+
     it('each on Set', function () {
       var set = new Set([1, 2, 3]);
 


### PR DESCRIPTION
This fixes `#each` block params for `Map` entries.

`execIteration(field, value, ...)` already receives the correct entry value, but the block param currently uses `context[field]`. That works for arrays and plain objects, but it is incorrect for `Map`.

For Map keys like `constructor` or `toString`, `context[field]` resolves properties on the Map object rather than the stored entry value, which can cause incorrect output or runtime errors.

This changes the block param value to use the already-resolved `value` argument and adds regression coverage for Map keys that collide with object/prototype property names.

Verified with:

- `npx vitest run --project node spec/builtins.js`