### PR TITLE
Fix compat Map depthed lookup

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -155,7 +155,7 @@ export function template(templateSpec, env) {
       for (let i = 0; i < len; i++) {
         let result = depths[i] && container.lookupProperty(depths[i], name);
         if (result != null) {
-          return depths[i][name];
+          return result;
         }
       }
     },

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -388,6 +388,18 @@ describe('basic context', function () {
       .toCompileTo('Goodbye beautiful world!');
   });
 
+  it('compat mode resolves Map values through depthed lookup', function () {
+    expectTemplate('{{#with nested}}{{value}}/{{constructor}}{{/with}}')
+      .withInput({
+        nested: new Map([
+          ['value', 'map-value'],
+          ['constructor', 'map-constructor'],
+        ]),
+      })
+      .withCompileOptions({ compat: true })
+      .toCompileTo('map-value/map-constructor');
+  });
+
   it('nested paths with empty string value', function () {
     expectTemplate('Goodbye {{alan/expression}} world!')
       .withInput({ alan: { expression: '' } })


### PR DESCRIPTION
This fixes Map value resolution in compat-mode depthed lookup.

`container.lookup()` already resolves values through `container.lookupProperty()`, which supports `Map` entries. However, after finding a result it returned `depths[i][name]`, which reads from the object property instead of returning the resolved value.

That caused compat mode to fail for Map entries and behave inconsistently with normal Map lookup.

This change returns the already-resolved value and adds regression coverage.

Verified with:

- `npx vitest run --project node spec/basic.js spec/security.js spec/builtins.js`
