### PR TITLE
Use guarded lookup for dynamic partial resolution

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -355,7 +355,7 @@ export function resolvePartial(partial, context, options) {
   } else if (!partial.call && !options.name) {
     // This is a dynamic partial that returned a string
     options.name = partial;
-    partial = options.partials[partial];
+    partial = this.lookupProperty(options.partials, partial);
   }
   return partial;
 }

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -70,6 +70,18 @@ describe('partials', function () {
       );
   });
 
+  it('dynamic partials should not resolve prototype properties', function () {
+    expectTemplate('{{> (partial)}}')
+      .withHelper('partial', function () {
+        return 'constructor';
+      })
+      .withPartials({})
+      .toThrow(
+        Handlebars.Exception,
+        'The partial "constructor" could not be found'
+      );
+  });
+
   it('partials with context', function () {
     expectTemplate('Dudes: {{>dude dudes}}')
       .withInput({


### PR DESCRIPTION
Dynamic partial string resolution used direct property access via:

`options.partials[partial]`

This bypassed the guarded property lookup semantics used elsewhere in the runtime.

As a result, prototype properties such as `constructor` could be resolved as dynamic partial candidates.

This change switches dynamic partial resolution to use `this.lookupProperty(...)` for consistency with existing runtime lookup behavior and prototype access controls.

Added regression coverage for prototype-property partial resolution.

Focused verification:
`npx vitest run --project node spec/partials.js`
