### PR TITLE
Use guarded lookup for static partial fallback resolution

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -350,7 +350,7 @@ export function resolvePartial(partial, context, options) {
     if (options.name === '@partial-block') {
       partial = options.data['partial-block'];
     } else {
-      partial = options.partials[options.name];
+      partial = this.lookupProperty(options.partials, options.name);
     }
   } else if (!partial.call && !options.name) {
     // This is a dynamic partial that returned a string

--- a/spec/partials.js
+++ b/spec/partials.js
@@ -163,6 +163,17 @@ describe('partials', function () {
     );
   });
 
+  it('static partial fallback should not resolve prototype properties', function () {
+    var partials = Object.create({ constructor: 'fail' });
+
+    expectTemplate('{{> constructor}}')
+      .withPartials(partials)
+      .toThrow(
+        Handlebars.Exception,
+        'The partial "constructor" could not be found'
+      );
+  });
+
   it('registering undefined partial throws an exception', function () {
     expect(function () {
       handlebarsEnv.registerPartial('undefined_test', undefined);


### PR DESCRIPTION
Static partial fallback resolution used direct property access via:

`options.partials[options.name]`

This bypassed the guarded property lookup semantics used elsewhere in the runtime.

As a result, inherited prototype properties such as `constructor` could resolve during fallback partial lookup.

This change switches fallback resolution to use `this.lookupProperty(...)` for consistency with existing runtime lookup behavior and prototype access controls.

Added regression coverage for prototype-property fallback resolution.

Focused verification:
`npx vitest run --project node spec/partials.js`
