### PR TITLE
fix: keep parent context for undefined #each item in block helper

### DIFF
--- a/lib/handlebars/runtime.js
+++ b/lib/handlebars/runtime.js
@@ -318,7 +318,7 @@ export function wrapProgram(
     if (
       depths &&
       context != depths[0] &&
-      !(context === container.nullContext && depths[0] === null)
+      !(context === container.nullContext && depths[0] == null)
     ) {
       currentDepths = [context].concat(depths);
     }

--- a/spec/regressions.js
+++ b/spec/regressions.js
@@ -502,4 +502,12 @@ describe('Regressions', function () {
         .toCompileTo('bar');
     });
   });
+
+  describe('GH-1762: parent context lost for undefined #each item inside a block helper', function () {
+    it('should keep the parent context when iterating an array with undefined items', function () {
+      expectTemplate('{{#each arr}}{{#if 1}}{{../foo}}|{{/if}}{{/each}}')
+        .withInput({ arr: [1, undefined, 3], foo: 'foo' })
+        .toCompileTo('foo|foo|foo|');
+    });
+  });
 });


### PR DESCRIPTION
Generally we like to see pull requests that

- [x] Please don't start pull requests for security issues. Instead, file a report at https://www.npmjs.com/advisories/report?package=handlebars
- [x] Maintain the existing code style
- [x] Are focused on a single change (i.e. avoid large refactoring or style adjustments in untouched code if not the primary goal of the pull request)
- [x] Have good commit messages
- [x] Have tests
- [x] Have the [typings](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html) (types/index.d.ts) updated on every API change. If you need help, updating those, please mention that in the PR description.
- [x] Don't significantly decrease the current code coverage (see coverage/lcov-report/index.html)
- [x] Please target the `master` branch in the PR.

When `#each` iterates an array containing an `undefined` element, the block context is `undefined`, so a nested block helper like `#if` invokes its body with `container.nullContext`; `wrapProgram` then failed to recognize the slot because the guard compared `depths[0] === null` while the slot held `undefined`, prepending an extra depth and shifting `../foo` out of reach. Loosening that comparison to `== null` keeps the parent context intact.

Closes #1762