### PR TITLE
fix: propagate strict mode to partial arguments

### DIFF
--- a/lib/handlebars/compiler/compiler.js
+++ b/lib/handlebars/compiler/compiler.js
@@ -186,6 +186,24 @@ Compiler.prototype = {
       this.accept(partial.name);
     }
 
+    // In strict mode the values passed to a partial (its context argument and
+    // any hash arguments) should be resolved strictly, so that referencing a
+    // missing variable throws just like it would in the parent template.
+    if (this.options.strict) {
+      for (const param of partial.params) {
+        if (param.type === 'PathExpression') {
+          param.strict = true;
+        }
+      }
+      if (partial.hash) {
+        for (const pair of partial.hash.pairs) {
+          if (pair.value.type === 'PathExpression') {
+            pair.value.strict = true;
+          }
+        }
+      }
+    }
+
     this.setupFullMustacheParams(partial, program, undefined, true);
 
     let indent = partial.indent || '';

--- a/spec/strict.js
+++ b/spec/strict.js
@@ -121,6 +121,48 @@ describe('strict', function () {
     });
   });
 
+  describe('strict partials', function () {
+    it('GH-1708: should error on missing variable referenced inside a partial', function () {
+      expectTemplate('{{> myPartial}}')
+        .withCompileOptions({ strict: true })
+        .withPartial('myPartial', 'Hello {{name}}')
+        .toThrow(Exception, /"name" not defined in/);
+
+      expectTemplate('{{> myPartial}}')
+        .withCompileOptions({ strict: true })
+        .withPartial('myPartial', 'Hello {{name}}')
+        .withInput({ name: 'World' })
+        .toCompileTo('Hello World');
+    });
+
+    it('GH-1708: should error on missing hash argument passed to a partial', function () {
+      expectTemplate('{{> myPartial name=name}}')
+        .withCompileOptions({ strict: true })
+        .withPartial('myPartial', 'Hello {{name}}')
+        .toThrow(Exception, /"name" not defined in/);
+
+      expectTemplate('{{> myPartial name=name}}')
+        .withCompileOptions({ strict: true })
+        .withPartial('myPartial', 'Hello {{name}}')
+        .withInput({ name: 'World' })
+        .toCompileTo('Hello World');
+    });
+
+    it('GH-1708: should error on missing context argument passed to a partial', function () {
+      expectTemplate('{{> myPartial person}}')
+        .withCompileOptions({ strict: true })
+        .withPartial('myPartial', 'Hello {{name}}')
+        .toThrow(Exception, /"person" not defined in/);
+    });
+
+    it('GH-1708: should error on a missing @data hash argument passed to a partial', function () {
+      expectTemplate('{{> myPartial name=@missing}}')
+        .withCompileOptions({ strict: true })
+        .withPartial('myPartial', 'Hello {{name}}')
+        .toThrow(Exception, /"missing" not defined in/);
+    });
+  });
+
   describe('strict and compat mode', function () {
     it('GH-1741: should render a simple variable', function () {
       expectTemplate('{{v}}')


### PR DESCRIPTION
## Summary
In `strict: true` mode, the values passed to a partial — its context argument and any hash arguments — were resolved with a non-strict lookup. So `compile('{{> myPartial name=name}}', { strict: true })` rendered an empty string when `name` was missing instead of throwing, unlike the identical lookup in a normal template.

The root cause is compile-time: strict lookups are emitted only for path expressions whose `strict` flag is set (set for normal mustaches but never for a partial's context/hash argument paths). This marks those path expressions as strict during compilation so a missing value throws a `"<name>" not defined` error, consistent with normal mustache lookups. The change is scoped to partials and gated on `options.strict`, so helper hash semantics are unchanged.

## Test plan
- New tests in `spec/strict.js` covering missing partial hash arg, context arg, and `@data` hash arg (throw) plus present-value cases (render)
- Full node suite passes; new tests fail without the fix

Closes #1708