### PR TITLE
Fix noEscape numeric values being added instead of concatenated

### DIFF
--- a/lib/handlebars/compiler/javascript-compiler.js
+++ b/lib/handlebars/compiler/javascript-compiler.js
@@ -426,7 +426,10 @@ JavaScriptCompiler.prototype = {
   // Otherwise, the empty string is appended
   append: function () {
     if (this.isInline()) {
-      this.replaceStack((current) => [' != null ? ', current, ' : ""']);
+      // Coerce non-null values to a String so that adjacent buffer appends are
+      // concatenated rather than combined by the merge `+` (e.g. numeric values
+      // such as `{{a}}{{b}}` with `noEscape` must yield "12", not 3).
+      this.replaceStack((current) => [' != null ? "" + ', current, ' : ""']);
 
       this.pushSource(this.appendToBuffer(this.popStack()));
     } else {

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -111,6 +111,22 @@ describe('basic context', function () {
       .toCompileTo('num: 0');
   });
 
+  it('does not add adjacent numeric values with noEscape', function () {
+    expectTemplate('{{a}}{{b}}')
+      .withCompileOptions({ noEscape: true })
+      .withInput({ a: 1, b: 2 })
+      .toCompileTo('12');
+
+    expectTemplate('{{a}}{{b}}{{c}}')
+      .withCompileOptions({ noEscape: true })
+      .withInput({ a: 1, b: 2, c: 3 })
+      .toCompileTo('123');
+
+    expectTemplate('{{{a}}}{{{b}}}')
+      .withInput({ a: 1, b: 2 })
+      .toCompileTo('12');
+  });
+
   it('false', function () {
     /* eslint-disable no-new-wrappers */
     expectTemplate('val1: {{val1}}, val2: {{val2}}')

--- a/spec/basic.js
+++ b/spec/basic.js
@@ -111,7 +111,7 @@ describe('basic context', function () {
       .toCompileTo('num: 0');
   });
 
-  it('does not add adjacent numeric values with noEscape', function () {
+  it('does not add adjacent numeric values with noEscape or raw mustaches', function () {
     expectTemplate('{{a}}{{b}}')
       .withCompileOptions({ noEscape: true })
       .withInput({ a: 1, b: 2 })


### PR DESCRIPTION
## Problem

Closes #1838.

With `noEscape: true`, adjacent mustaches that resolve to numbers are **added** instead of concatenated:

```js
Handlebars.compile('{{a}}{{b}}', { noEscape: true })({ a: 1, b: 2 });
// => "3"   (expected "12")

Handlebars.compile('{{a}}{{b}}{{c}}', { noEscape: true })({ a: 1, b: 2, c: 3 });
// => "6"   (expected "123")
```

The default (escaped) path is unaffected because values go through `escapeExpression`, which returns a string. The triple-stash raw form `{{{a}}}{{{b}}}` is affected by the same root cause.

## Root cause

In `JavaScriptCompiler#append`, the inline output path emitted the **raw value**:

```js
this.replaceStack((current) => [' != null ? ', current, ' : ""']);
// compiles to:  (stack1 != null ? stack1 : "")
```

Adjacent buffer appends are merged with ` + ` in `mergeSource`. When the merged expression starts with these raw values and both are numbers, JavaScript performs numeric addition (`1 + 2 === 3`) before the top-level `'' +` in the runtime ever runs.

The escaped path wraps each value in `escapeExpression(...)` (always a string), so the merge concatenates correctly. The unescaped path should likewise produce a string — the method's own doc comment states it *"Coerces `value` to a String"*, but the inline branch did not.

## Fix

Coerce the non-null value to a string in the inline append, mirroring the escaped path:

```js
this.replaceStack((current) => [' != null ? "" + ', current, ' : ""']);
```

`null`/`undefined` still produce `""`, `SafeString`s still emit their raw (unescaped) HTML, and escaped output is untouched. +4/−1 in the compiler.

## Tests

Added a regression test in `spec/basic.js` (`noEscape` for `{{a}}{{b}}` / `{{a}}{{b}}{{c}}` and triple-stash `{{{a}}}{{{b}}}`). Verified it **fails without the fix** (`Expected "12", Received "3"`) and passes with it. Full node suite green (604 passing). `oxlint` and `oxfmt` clean.

No public API change, so `types/index.d.ts` is unchanged.