### PR TITLE
docs: fix broken JavaScriptCompiler subclass example

### DIFF
--- a/docs/compiler-api.md
+++ b/docs/compiler-api.md
@@ -321,13 +321,13 @@ The `Handlebars.JavaScriptCompiler` object has a number of methods that may be c
 ### Example for the compiler api.
 
 This example makes context property lookups case-insensitive by lowercasing the
-name at compile time, so `{{Test}}` resolves `test`. This illustrates how
-compiler behavior can be changed.
+name at compile time, so `{{#each Test}}` / `{{Value}}` resolve `test` / `value`.
+This illustrates how compiler behavior can be changed.
 
 Note: calling a registered helper from `nameLookup` (for example via
 `helpers.lookupLowerCase`) is not reliable since Handlebars 4.6, because helper
-wrappers treat the last argument as options. Prefer generating
-`lookupProperty(...)` calls as shown below.
+wrappers treat the last argument as options. Lowercase the name, then delegate
+to the base `nameLookup` so the example keeps working as compiler internals change.
 
 ```javascript
 function MyCompiler() {
@@ -340,22 +340,14 @@ MyCompiler.prototype.compiler = MyCompiler;
 
 MyCompiler.prototype.nameLookup = function (parent, name, type) {
   if (type === 'context') {
-    this.lookupPropertyFunctionIsUsed = true;
-    return [
-      'lookupProperty(',
-      parent,
-      ',',
-      JSON.stringify(String(name).toLowerCase()),
-      ')',
-    ];
-  } else {
-    return Handlebars.JavaScriptCompiler.prototype.nameLookup.call(
-      this,
-      parent,
-      name,
-      type
-    );
+    name = String(name).toLowerCase();
   }
+  return Handlebars.JavaScriptCompiler.prototype.nameLookup.call(
+    this,
+    parent,
+    name,
+    type
+  );
 };
 
 var env = Handlebars.create();

--- a/docs/compiler-api.md
+++ b/docs/compiler-api.md
@@ -320,25 +320,34 @@ The `Handlebars.JavaScriptCompiler` object has a number of methods that may be c
 
 ### Example for the compiler api.
 
-This example changes all lookups of properties are performed by a helper (`lookupLowerCase`) which looks for `test` if `{{Test}}` occurs in the template. This is just to illustrate how compiler behavior can be change.
+This example makes context property lookups case-insensitive by lowercasing the
+name at compile time, so `{{Test}}` resolves `test`. This illustrates how
+compiler behavior can be changed.
 
-There is also [a jsfiddle with this code](https://jsfiddle.net/9D88g/162/) if you want to play around with it.
+Note: calling a registered helper from `nameLookup` (for example via
+`helpers.lookupLowerCase`) is not reliable since Handlebars 4.6, because helper
+wrappers treat the last argument as options. Prefer generating
+`lookupProperty(...)` calls as shown below.
 
 ```javascript
 function MyCompiler() {
   Handlebars.JavaScriptCompiler.apply(this, arguments);
 }
-MyCompiler.prototype = new Handlebars.JavaScriptCompiler();
+MyCompiler.prototype = Object.create(Handlebars.JavaScriptCompiler.prototype);
 
-// Use this compile to compile BlockStatment-Blocks
+// Use this compiler for nested BlockStatement blocks
 MyCompiler.prototype.compiler = MyCompiler;
 
 MyCompiler.prototype.nameLookup = function (parent, name, type) {
   if (type === 'context') {
-    return this.source.functionCall('helpers.lookupLowerCase', '', [
+    this.lookupPropertyFunctionIsUsed = true;
+    return [
+      'lookupProperty(',
       parent,
-      JSON.stringify(name),
-    ]);
+      ',',
+      JSON.stringify(String(name).toLowerCase()),
+      ')',
+    ];
   } else {
     return Handlebars.JavaScriptCompiler.prototype.nameLookup.call(
       this,
@@ -350,10 +359,6 @@ MyCompiler.prototype.nameLookup = function (parent, name, type) {
 };
 
 var env = Handlebars.create();
-env.registerHelper('lookupLowerCase', function (parent, name) {
-  return parent[name.toLowerCase()];
-});
-
 env.JavaScriptCompiler = MyCompiler;
 
 var template = env.compile('{{#each Test}} ({{Value}}) {{/each}}');

--- a/docs/compiler-api.md
+++ b/docs/compiler-api.md
@@ -321,7 +321,7 @@ The `Handlebars.JavaScriptCompiler` object has a number of methods that may be c
 ### Example for the compiler api.
 
 This example makes context property lookups case-insensitive by lowercasing the
-name at compile time, so `{{#each Test}}` / `{{Value}}` resolve `test` / `value`.
+name at compile time, so `{{#each Test}}` / `{{Value}}` resolve to `test` / `value`.
 This illustrates how compiler behavior can be changed.
 
 Note: calling a registered helper from `nameLookup` (for example via
@@ -334,6 +334,7 @@ function MyCompiler() {
   Handlebars.JavaScriptCompiler.apply(this, arguments);
 }
 MyCompiler.prototype = Object.create(Handlebars.JavaScriptCompiler.prototype);
+MyCompiler.prototype.constructor = MyCompiler;
 
 // Use this compiler for nested BlockStatement blocks
 MyCompiler.prototype.compiler = MyCompiler;


### PR DESCRIPTION
## Summary

- Update the JavaScriptCompiler subclass example in `docs/compiler-api.md` so it works on Handlebars 4.6+.
- Generate `lookupProperty(...)` with a lowercased name instead of calling a registered helper from `nameLookup`.
- Use `Object.create` for the prototype and note why the old helper-based approach fails.

Fixes #1912

## Test plan

- [ ] Confirm the compiler-api docs example matches current Handlebars compiler internals
- [ ] Spot-check that the documented approach works on Handlebars 4.6+