### PR TITLE
Fix `blockHelperMissing` rendering the block for an empty string

### DIFF
--- a/lib/handlebars/helpers/block-helper-missing.js
+++ b/lib/handlebars/helpers/block-helper-missing.js
@@ -7,7 +7,7 @@ export default function (instance) {
 
     if (context === true) {
       return fn(this);
-    } else if (context === false || context == null) {
+    } else if (context === false || context == null || context === '') {
       return inverse(this);
     } else if (isArray(context)) {
       if (context.length > 0) {

--- a/spec/blocks.js
+++ b/spec/blocks.js
@@ -168,6 +168,20 @@ describe('blocks', function () {
         .toCompileTo('Right On!');
     });
 
+    it('inverted section with empty string value', function () {
+      expectTemplate(
+        '{{#goodbyes}}{{this}}{{/goodbyes}}{{^goodbyes}}Right On!{{/goodbyes}}'
+      )
+        .withInput({ goodbyes: '' })
+        .withMessage('Inverted section rendered when value is an empty string.')
+        .toCompileTo('Right On!');
+
+      expectTemplate('{{#a.b}}yes{{else}}no{{/a.b}}')
+        .withInput({ a: { b: '' } })
+        .withMessage('Else section rendered for a pathed empty string value.')
+        .toCompileTo('no');
+    });
+
     it('block inverted sections', function () {
       expectTemplate('{{#people}}{{name}}{{^}}{{none}}{{/people}}')
         .withInput({ none: 'No people' })


### PR DESCRIPTION
An empty string fell through to the truthy branch, so `{{#value}}` unexpectedly rendered its block instead of the inverse when `value` was `''`. Treat `''` as falsy alongside `null`, `undefined` and `false`.

This doesn't break any existing tests, so the previous behavior seems to have been an oversight rather than intentional. Rendering a block with an empty string as context isn't useful in practice.

This is an important compatibility fix, since it is common in Mustache templates to use a block section to conditionally output a tag or attribute only if it has content. E.g:

```hbs
{{#notes}}<p class="notes">{{notes}}</p>{{/notes}}
```

```hbs
<button{{#id}} id="{{ id }}"{{/id}}>Click me</button>
```

```hbs
{{#user}}
  {{name}}{{^name}}<i>Anonymous</i>{{/name}}
{{/user}}
```

Resolves #2177